### PR TITLE
Fix unknown request.status

### DIFF
--- a/NHentai/sync/infra/adapters/request/http/implementations/sync.py
+++ b/NHentai/sync/infra/adapters/request/http/implementations/sync.py
@@ -34,7 +34,7 @@ class RequestsAdapter(RequestInterface):
         if handler is not None:
             raise handler()
         
-        raise Exception(f'An unexpected error occoured while making the request to the website! status code: {request.status}')
+        raise Exception(f'An unexpected error occoured while making the request to the website! status code: {request.status_code}')
         
 
     def get(self, url: str, params: Union[Dict[str, Any], None]=None, headers: Union[Dict[str, Any], None]=None) -> RequestResponse:


### PR DESCRIPTION
Fix error if `request.status_code` is 503

```
  File "[...]/site-packages/NHentai/sync/infra/adapters/request/http/implementations/sync.py", line 37, in handle_error
    raise Exception(f'An unexpected error occoured while making the request to the website! status code: {request.status}')
AttributeError: 'Response' object has no attribute 'status'
```